### PR TITLE
GPII-2725: Updating Infusion to get fix for FLUID-6228.

### DIFF
--- a/extension/src/lib/PrefsEditorInstantiation.js
+++ b/extension/src/lib/PrefsEditorInstantiation.js
@@ -26,6 +26,15 @@ $("document").ready(function () {
                         listener: "fluid.prefs.arrowScrolling.scrollToPanel",
                         args: ["{that}", "{that}.model.panelIndex"]
                     }
+                },
+                // TODO: Remove this modelListener after FLUID-6230 is addressed
+                // https://issues.fluidproject.org/browse/FLUID-6230
+                modelListeners: {
+                    "panelIndex": {
+                        listener: "fluid.prefs.arrowScrolling.scrollToPanel",
+                        args: ["{that}", "{that}.model.panelIndex"],
+                        includeSource: "scrollEvent"
+                    }
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "test": "node tests/node/all-tests.js"
   },
   "dependencies": {
-    "infusion": "3.0.0-dev.20171102T191539Z.c0636b395",
+    "infusion": "3.0.0-dev.20171121T212609Z.9b4fde781",
     "ws": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This add the fix from Infusion for FLUID-6228; which allows the pallette panels to scroll into view when they are tab focused. The implementation isn't perfect, as only a portion scrolls into view. This is because it's a set of radio buttons positioned horizontally. The other controls are single input elements located in the centre of the panel.

https://issues.gpii.net/browse/GPII-2725