### PR TITLE
GPII-3373: Temporarily removing the full page TTS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following adaptations are supported:
 * Contrast
 * Right-Click to Select
 * Selection Highlight
-* Text-to-Speech
+* Text-to-Speech (only for selected text)
 * Reading Mode
 * Table of Contents
 * Enhance Inputs

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "UI Options Plus (UIO+)",
     "short_name": "UIO+",
-    "version": "0.1.0.5",
+    "version": "0.1.0.6",
     "description": "User Interface Options Plus (UIO+) allows you to customize websites to match your own personal needs and preferences.",
     "author": "Fluid Project",
     "permissions": [

--- a/extension/src/content_scripts/domEnactor.js
+++ b/extension/src/content_scripts/domEnactor.js
@@ -127,6 +127,21 @@
                 options: {
                     model: {
                         enabled: "{domEnactor}.model.selfVoicingEnabled"
+                    },
+                    // GPII-3373: temporarily remove the page level TTS until GPII-3286 is fixed
+                    components: {
+                        orator: {
+                            options: {
+                                components: {
+                                    controller: {
+                                        type: "fluid.emptySubcomponent"
+                                    },
+                                    domReader: {
+                                        type: "fluid.emptySubcomponent"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://issues.gpii.net/browse/GPII-3373

This needs to be merged and published to the Chrome Web Store before Sep 25 because it is needed for the Pilot testing.