### PR TITLE
GPII-3386: Update UIO+ zoom from browser zoom changes.

### DIFF
--- a/extension/src/lib/PrefsEditor.js
+++ b/extension/src/lib/PrefsEditor.js
@@ -177,7 +177,14 @@
                 "range.max": "maximum",
                 "step": "divisibleBy"
             }
-        }
+        },
+        distributeOptions: [{
+            record: {
+                scale: 2
+            },
+            target: "{that textfieldStepper}.options",
+            namespace: "scale"
+        }]
     });
 
     fluid.defaults("gpii.chrome.prefs.panel.lineSpace", {
@@ -382,8 +389,8 @@
             "gpii.chrome.prefs.textSize": {
                 "type": "number",
                 "default": 1,
-                "minimum": 0.5,
-                "maximum": 4,
+                "minimum": 0.25,
+                "maximum": 5,
                 "divisibleBy": 0.1
             }
         }

--- a/extension/src/lib/zoom.js
+++ b/extension/src/lib/zoom.js
@@ -75,7 +75,14 @@ fluid.defaults("gpii.chrome.zoom", {
 });
 
 gpii.chrome.zoom.bindEvents = function (that) {
-    chrome.tabs.onZoomChange.addListener(that.events.onZoomChanged.fire);
+    chrome.tabs.onZoomChange.addListener(function (ZoomChangeInfo) {
+        // Only fire the onZoomChanged event if the Zoom factor is actually different.
+        // This is necessary because chrome will fire its onZoomChange event when a new tab or window is opened;
+        // with old and new zoom factors of 0. If this check isn't here, it will cause all pages to be reset.
+        if (ZoomChangeInfo.oldZoomFactor !== ZoomChangeInfo.newZoomFactor) {
+            that.events.onZoomChanged.fire(ZoomChangeInfo);
+        }
+    });
 };
 
 gpii.chrome.zoom.applyZoomInTab = function (that, tab, value) {

--- a/extension/src/lib/zoom.js
+++ b/extension/src/lib/zoom.js
@@ -28,7 +28,8 @@ fluid.defaults("gpii.chrome.zoom", {
         onError: null,
         onTabOpened: null,
         onTabUpdated: null,
-        onWindowFocusChanged: null
+        onWindowFocusChanged: null,
+        onZoomChanged: null
     },
     eventRelayMap: {
         "chrome.tabs.onCreated": "onTabOpened",
@@ -56,6 +57,7 @@ fluid.defaults("gpii.chrome.zoom", {
         }
     },
     listeners: {
+        "onCreate.bindEvents": "gpii.chrome.zoom.bindEvents",
         "onTabOpened.setupTab": {
             funcName: "{that}.updateTab",
             args: "{arguments}.0"
@@ -64,9 +66,17 @@ fluid.defaults("gpii.chrome.zoom", {
             funcName: "{that}.updateTab",
             args: "{arguments}.2"
         },
-        "onWindowFocusChanged.applyZoomSettings": "{that}.applyZoomSettings"
+        "onWindowFocusChanged.applyZoomSettings": "{that}.applyZoomSettings",
+        "onZoomChanged": {
+            changePath: "magnification",
+            value: "{arguments}.0.newZoomFactor"
+        }
     }
 });
+
+gpii.chrome.zoom.bindEvents = function (that) {
+    chrome.tabs.onZoomChange.addListener(that.events.onZoomChanged.fire);
+};
 
 gpii.chrome.zoom.applyZoomInTab = function (that, tab, value) {
     // set the zoom value if it hasn't already been set.

--- a/tests/shared/zoomTestDefs.js
+++ b/tests/shared/zoomTestDefs.js
@@ -46,6 +46,9 @@ fluid.defaults("gpii.chrome.tests.zoom.tester", {
         magnification: 2,
         magnifierEnabled: true
     },
+    browserZoom: {
+        newZoomFactor: 2.5
+    },
     disableZoom: {
         magnifierEnabled: false
     },
@@ -143,7 +146,32 @@ fluid.defaults("gpii.chrome.tests.zoom.tester", {
                        "{that}.options.newZoomLevel.magnification"]
             }]
         }, {
-            name: "magnification changes, tabs are updated",
+            name: "magnification changed through browser",
+            expect: 6,
+            sequence: [{
+                funcName: "{zoom}.events.onZoomChanged.fire",
+                args: ["{that}.options.browserZoom"]
+            }, {
+                event: "{that}.events.onSetZoom",
+                listener: "gpii.chrome.tests.zoom.checkSetZoom",
+                args: ["{arguments}.0", "{arguments}.1",
+                       "{that}.options.tabs.0.id",
+                       "{that}.options.browserZoom.newZoomFactor"]
+            }, {
+                event: "{that}.events.onSetZoom",
+                listener: "gpii.chrome.tests.zoom.checkSetZoom",
+                args: ["{arguments}.0", "{arguments}.1",
+                       "{that}.options.tabs.1.id",
+                       "{that}.options.browserZoom.newZoomFactor"]
+            }, {
+                event: "{that}.events.onSetZoom",
+                listener: "gpii.chrome.tests.zoom.checkSetZoom",
+                args: ["{arguments}.0", "{arguments}.1",
+                       "{that}.options.tabs.2.id",
+                       "{that}.options.browserZoom.newZoomFactor"]
+            }]
+        }, {
+            name: "magnification disabled, tabs are updated",
             expect: 6,
             sequence: [{
                 funcName: "gpii.chrome.tests.zoom.setSettings",


### PR DESCRIPTION
Allow UIO+ zoom to be set based off of changes made directly to the browser's zoom. For example this would allow a user to make use of the browser's keyboard shortcuts for changing the zoom factor.

https://issues.gpii.net/browse/GPII-3386

I believe this will supersede https://github.com/GPII/gpii-chrome-extension/pull/16.