### PR TITLE
GPII-4398: renamed contrast feature classes

### DIFF
--- a/extension/css/calJobs.css
+++ b/extension/css/calJobs.css
@@ -4,22 +4,22 @@
 }
 
 /* High contrast */
-.gpii-ext-theme-yb a, .gpii-ext-theme-yb div,
-.gpii-ext-theme-by a, .gpii-ext-theme-by div,
-.gpii-ext-theme-bw a, .gpii-ext-theme-bw div,
-.gpii-ext-theme-wb a, .gpii-ext-theme-wb div,
-.gpii-ext-theme-gd a, .gpii-ext-theme-gd div,
-.gpii-ext-theme-gw a, .gpii-ext-theme-gw div,
-.gpii-ext-theme-bbr a, .gpii-ext-theme-bbr div {
+.fl-theme-uioPlus-yb a, .fl-theme-uioPlus-yb div,
+.fl-theme-uioPlus-by a, .fl-theme-uioPlus-by div,
+.fl-theme-uioPlus-bw a, .fl-theme-uioPlus-bw div,
+.fl-theme-uioPlus-wb a, .fl-theme-uioPlus-wb div,
+.fl-theme-uioPlus-gd a, .fl-theme-uioPlus-gd div,
+.fl-theme-uioPlus-gw a, .fl-theme-uioPlus-gw div,
+.fl-theme-uioPlus-bbr a, .fl-theme-uioPlus-bbr div {
     background-image: none !important;
 }
 
-.gpii-ext-theme-yb input, .gpii-ext-theme-yb button,
-.gpii-ext-theme-bw input, .gpii-ext-theme-bw button,
-.gpii-ext-theme-by input, .gpii-ext-theme-by button,
-.gpii-ext-theme-bbr input, .gpii-ext-theme-bbr button,
-.gpii-ext-theme-wb input, .gpii-ext-theme-wb button,
-.gpii-ext-theme-gd input, .gpii-ext-theme-gd button,
-.gpii-ext-theme-gw input, .gpii-ext-theme-gw button {
+.fl-theme-uioPlus-yb input, .fl-theme-uioPlus-yb button,
+.fl-theme-uioPlus-bw input, .fl-theme-uioPlus-bw button,
+.fl-theme-uioPlus-by input, .fl-theme-uioPlus-by button,
+.fl-theme-uioPlus-bbr input, .fl-theme-uioPlus-bbr button,
+.fl-theme-uioPlus-wb input, .fl-theme-uioPlus-wb button,
+.fl-theme-uioPlus-gd input, .fl-theme-uioPlus-gd button,
+.fl-theme-uioPlus-gw input, .fl-theme-uioPlus-gw button {
     border: 1px solid currentColor;
 }

--- a/extension/src/content_scripts/domEnactor.js
+++ b/extension/src/content_scripts/domEnactor.js
@@ -246,13 +246,13 @@
         gradeNames: ["fluid.prefs.enactor.contrast"],
         classes: {
             "default": "",
-            "bw": "gpii-ext-theme-bw",
-            "wb": "gpii-ext-theme-wb",
-            "by": "gpii-ext-theme-by",
-            "yb": "gpii-ext-theme-yb",
-            "gd": "gpii-ext-theme-gd",
-            "gw": "gpii-ext-theme-gw",
-            "bbr": "gpii-ext-theme-bbr"
+            "bw": "fl-theme-uioPlus-bw",
+            "wb": "fl-theme-uioPlus-wb",
+            "by": "fl-theme-uioPlus-by",
+            "yb": "fl-theme-uioPlus-yb",
+            "gd": "fl-theme-uioPlus-gd",
+            "gw": "fl-theme-uioPlus-gw",
+            "bbr": "fl-theme-uioPlus-bbr"
         }
     });
 

--- a/extension/stylus/enactors.styl
+++ b/extension/stylus/enactors.styl
@@ -11,23 +11,23 @@
 // to avoid conflicts when the browser extension is run on a page that already
 // includes UI Options.
 extensionThemes = {
-    ".gpii-ext-theme-bw": {
+    ".fl-theme-uioPlus-bw": {
         foregroundColor: #000000,
         backgroundColor: #ffffff
     }
-    ".gpii-ext-theme-wb": {
+    ".fl-theme-uioPlus-wb": {
         foregroundColor: #ffffff,
         backgroundColor: #000000
     }
-    ".gpii-ext-theme-yb": {
+    ".fl-theme-uioPlus-yb": {
         foregroundColor: #ffff00,
         backgroundColor: #000000
     }
-    ".gpii-ext-theme-by": {
+    ".fl-theme-uioPlus-by": {
         foregroundColor: #000000,
         backgroundColor: #ffff00
     }
-    ".gpii-ext-theme-gd": {
+    ".fl-theme-uioPlus-gd": {
         foregroundColor: #888888,
         backgroundColor: #222222,
         linkColor: #8080ff,
@@ -37,7 +37,7 @@ extensionThemes = {
         buttonForegroundColor: #ffffff,
         buttonBackgroundColor: #000000
     }
-    ".gpii-ext-theme-gw": {
+    ".fl-theme-uioPlus-gw": {
         foregroundColor: #6c6c6c,
         backgroundColor: #ffffff,
         linkColor: #6666cc,
@@ -47,7 +47,7 @@ extensionThemes = {
         buttonForegroundColor: #000000,
         buttonBackgroundColor: #ffffff
     }
-    ".gpii-ext-theme-bbr": {
+    ".fl-theme-uioPlus-bbr": {
         foregroundColor: #000000,
         backgroundColor: #bb9966,
         linkColor: #000099,


### PR DESCRIPTION
In response to the JIRA issue [GPII-4398](https://issues.gpii.net/browse/GPII-4398), I have renamed all the contrast classes. Now instead of classes starting from gpii-ext-theme, they are following convention fl-theme-uioPlus.