### PR TITLE
GPII-4241 : Added command to open UIO+ panel from the keyboard

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,17 +26,10 @@
         "128": "images/GearHeart_Mixed_127x127.png"
     },
     "commands": {
-        "toggle-feature": {
-            "suggested_key": {
-                "default": "Ctrl+Shift+F",
-                "mac": "MacCtrl+Shift+F"
-            },
-            "description": "Send a 'toggle-feature' event to the extension"
-        },
         "_execute_browser_action": {
             "suggested_key": {
-                "default": "Ctrl+Shift+Y",
-                "mac": "MacCtrl+Shift+Y"
+                "windows": "Ctrl+Shift+U",
+                "mac": "Command+Shift+U"
             }
         }
     },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -25,6 +25,17 @@
         "48": "images/GearHeart_Mixed_47x47.png",
         "128": "images/GearHeart_Mixed_127x127.png"
     },
+    // added a keyboard shortcut or command to open the panel
+    "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+              "windows": "Alt+O",
+              "mac": "Command+Shift+Y",
+              "chromeos": "Ctrl+Shift+U"
+            }
+        }
+    },
+    //
     "content_scripts": [{
         "matches": ["<all_urls>"],
         "css": [

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -25,17 +25,21 @@
         "48": "images/GearHeart_Mixed_47x47.png",
         "128": "images/GearHeart_Mixed_127x127.png"
     },
-    // added a keyboard shortcut or command to open the panel
     "commands": {
+        "toggle-feature": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+F",
+                "mac": "MacCtrl+Shift+F"
+            },
+            "description": "Send a 'toggle-feature' event to the extension"
+        },
         "_execute_browser_action": {
             "suggested_key": {
-              "windows": "Alt+O",
-              "mac": "Command+Shift+Y",
-              "chromeos": "Ctrl+Shift+U"
+                "default": "Ctrl+Shift+Y",
+                "mac": "MacCtrl+Shift+Y"
             }
         }
     },
-    //
     "content_scripts": [{
         "matches": ["<all_urls>"],
         "css": [


### PR DESCRIPTION
In response to the JIRA issue GPII-4241, I have provided keyboard shortcut to UIO+ extension. Now you can directly open the extension panel using "Ctrl+Shift+U" as a keyboard shortcut.