### PR TITLE
GPII-4241: Added shortcut key for UIO+

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,6 +19,13 @@
             "32": "images/gears_32.png"
         }
     },
+    "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+U"
+            }
+        }
+    },
     "icons": {
         "16": "images/GearHeart_Mixed_15x15.png",
         "32": "images/GearHeart_Mixed_31x31.png",


### PR DESCRIPTION
In response to the JIRA issue GPII-4241, I have provided keyboard shortcut to UIO+ extension. Now you can directly open the extension panel using "Ctrl+Shift+U" as a keyboard shortcut.